### PR TITLE
Fix LossRecorder state saving

### DIFF
--- a/hv_train.py
+++ b/hv_train.py
@@ -616,14 +616,14 @@ class FineTuningTrainer:
             **lr_scheduler_kwargs,
         )
 
-    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> bool:
+    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> str | None:
         if not args.resume:
-            return False
+            return None
 
         if not args.resume_from_huggingface:
             logger.info(f"resume training from local state: {args.resume}")
             accelerator.load_state(args.resume)
-            return True
+            return args.resume
 
         logger.info(f"resume training from huggingface state: {args.resume}")
         repo_id = args.resume.split("/")[0] + "/" + args.resume.split("/")[1]
@@ -668,7 +668,7 @@ class FineTuningTrainer:
         dirname = os.path.dirname(results[0])
         accelerator.load_state(dirname)
 
-        return True
+        return dirname
 
     def sample_images(self, accelerator, args, epoch, global_step, device, vae, transformer, sample_parameters):
         pass
@@ -917,7 +917,7 @@ class FineTuningTrainer:
             accelerator.scaler._unscale_grads_ = _unscale_grads_replacer
 
         # resume from local or huggingface. accelerator.step is set
-        self.resume_from_local_or_hf_if_specified(accelerator, args)  # accelerator.load_state(args.resume)
+        state_dir = None  # will be used after loss_recorder is created
 
         # epoch数を計算する
         num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
@@ -957,6 +957,9 @@ class FineTuningTrainer:
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
+        state_dir = self.resume_from_local_or_hf_if_specified(accelerator, args) if state_dir is None else state_dir
+        if state_dir is not None:
+            train_utils.load_loss_recorder(state_dir, loss_recorder)
         del train_dataset_group
 
         # function for saving/removing
@@ -1126,7 +1129,7 @@ class FineTuningTrainer:
                             save_model(ckpt_name, accelerator.unwrap_model(transformer), global_step, epoch)
 
                             if args.save_state:
-                                train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
+                                train_utils.save_and_remove_state_stepwise(args, accelerator, global_step, loss_recorder)
 
                             remove_step_no = train_utils.get_remove_step_no(args, global_step)
                             if remove_step_no is not None:
@@ -1167,7 +1170,7 @@ class FineTuningTrainer:
                         remove_model(remove_ckpt_name)
 
                     if args.save_state:
-                        train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                        train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1, loss_recorder)
 
             self.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, transformer, sample_parameters)
             optimizer_train_fn()
@@ -1181,7 +1184,7 @@ class FineTuningTrainer:
         optimizer_eval_fn()
 
         if args.save_state or args.save_state_on_train_end:
-            train_utils.save_state_on_train_end(args, accelerator)
+            train_utils.save_state_on_train_end(args, accelerator, loss_recorder)
 
         if is_main_process:
             ckpt_name = train_utils.get_last_ckpt_name(args.output_name)

--- a/hv_train_network.py
+++ b/hv_train_network.py
@@ -676,14 +676,14 @@ class NetworkTrainer:
             **lr_scheduler_kwargs,
         )
 
-    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> bool:
+    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> str | None:
         if not args.resume:
-            return False
+            return None
 
         if not args.resume_from_huggingface:
             logger.info(f"resume training from local state: {args.resume}")
             accelerator.load_state(args.resume)
-            return True
+            return args.resume
 
         logger.info(f"resume training from huggingface state: {args.resume}")
         repo_id = args.resume.split("/")[0] + "/" + args.resume.split("/")[1]
@@ -728,7 +728,7 @@ class NetworkTrainer:
         dirname = os.path.dirname(results[0])
         accelerator.load_state(dirname)
 
-        return True
+        return dirname
 
     def get_noisy_model_input_and_timesteps(
         self,
@@ -1679,7 +1679,7 @@ class NetworkTrainer:
         accelerator.register_load_state_pre_hook(load_model_hook)
 
         # resume from local or huggingface. accelerator.step is set
-        self.resume_from_local_or_hf_if_specified(accelerator, args)  # accelerator.load_state(args.resume)
+        state_dir = None  # will be used after loss_recorder is created
 
         # epoch数を計算する
         num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
@@ -1804,6 +1804,9 @@ class NetworkTrainer:
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
+        state_dir = self.resume_from_local_or_hf_if_specified(accelerator, args) if state_dir is None else state_dir
+        if state_dir is not None:
+            train_utils.load_loss_recorder(state_dir, loss_recorder)
         del train_dataset_group
 
         # function for saving/removing
@@ -1959,7 +1962,7 @@ class NetworkTrainer:
                                 save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch)
 
                                 if args.save_state:
-                                    train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
+                                    train_utils.save_and_remove_state_stepwise(args, accelerator, global_step, loss_recorder)
 
                                 remove_step_no = train_utils.get_remove_step_no(args, global_step)
                                 if remove_step_no is not None:
@@ -2008,7 +2011,7 @@ class NetworkTrainer:
                         remove_model(remove_ckpt_name)
 
                     if args.save_state:
-                        train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                        train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1, loss_recorder)
 
             self.sample_images(accelerator, args, epoch + 1, global_step, vae, transformer, sample_parameters, dit_dtype)
             optimizer_train_fn()
@@ -2025,7 +2028,7 @@ class NetworkTrainer:
         optimizer_eval_fn()
 
         if is_main_process and (args.save_state or args.save_state_on_train_end):
-            train_utils.save_state_on_train_end(args, accelerator)
+            train_utils.save_state_on_train_end(args, accelerator, loss_recorder)
 
         if is_main_process:
             ckpt_name = train_utils.get_last_ckpt_name(args.output_name)

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import shutil
+import json
 
 import accelerate
 import torch
@@ -78,6 +79,27 @@ class LossRecorder:
         return self.loss_total / len(self.loss_list)
 
 
+def save_loss_recorder(state_dir: str, loss_recorder: LossRecorder) -> None:
+    path = os.path.join(state_dir, "loss_recorder.json")
+    data = {
+        "loss_list": loss_recorder.loss_list,
+        "loss_total": loss_recorder.loss_total,
+    }
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def load_loss_recorder(state_dir: str, loss_recorder: LossRecorder) -> bool:
+    path = os.path.join(state_dir, "loss_recorder.json")
+    if not os.path.exists(path):
+        return False
+    with open(path, "r") as f:
+        data = json.load(f)
+    loss_recorder.loss_list = data.get("loss_list", [])
+    loss_recorder.loss_total = data.get("loss_total", 0.0)
+    return True
+
+
 def get_epoch_ckpt_name(model_name, epoch_no: int):
     return EPOCH_FILE_NAME.format(model_name, epoch_no) + ".safetensors"
 
@@ -113,7 +135,7 @@ def get_remove_step_no(args: argparse.Namespace, step_no: int):
     return remove_step_no
 
 
-def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: accelerate.Accelerator, epoch_no: int):
+def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: accelerate.Accelerator, epoch_no: int, loss_recorder: LossRecorder):
     model_name = args.output_name
 
     logger.info("")
@@ -122,6 +144,7 @@ def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: ac
 
     state_dir = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, epoch_no))
     accelerator.save_state(state_dir)
+    save_loss_recorder(state_dir, loss_recorder)
     if args.save_state_to_huggingface:
         logger.info("uploading state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
@@ -135,7 +158,7 @@ def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: ac
             shutil.rmtree(state_dir_old)
 
 
-def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accelerate.Accelerator, step_no: int):
+def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accelerate.Accelerator, step_no: int, loss_recorder: LossRecorder):
     model_name = args.output_name
 
     logger.info("")
@@ -144,6 +167,7 @@ def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accele
 
     state_dir = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, step_no))
     accelerator.save_state(state_dir)
+    save_loss_recorder(state_dir, loss_recorder)
     if args.save_state_to_huggingface:
         logger.info("uploading state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
@@ -161,7 +185,7 @@ def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accele
                 shutil.rmtree(state_dir_old)
 
 
-def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Accelerator):
+def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Accelerator, loss_recorder: LossRecorder):
     model_name = args.output_name
 
     logger.info("")
@@ -170,6 +194,7 @@ def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Ac
 
     state_dir = os.path.join(args.output_dir, LAST_STATE_NAME.format(model_name))
     accelerator.save_state(state_dir)
+    save_loss_recorder(state_dir, loss_recorder)
 
     if args.save_state_to_huggingface:
         logger.info("uploading last state to huggingface.")


### PR DESCRIPTION
## Summary
- allow resuming training with previous loss averages
- store LossRecorder state when saving checkpoints
- restore LossRecorder state on resume

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865195136b88321829a17a2233f50ec