### PR TITLE
Persist LossRecorder across training sessions

### DIFF
--- a/hv_train.py
+++ b/hv_train.py
@@ -957,6 +957,7 @@ class FineTuningTrainer:
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
+        accelerator.register_for_checkpointing(loss_recorder)
         del train_dataset_group
 
         # function for saving/removing

--- a/hv_train_network.py
+++ b/hv_train_network.py
@@ -1804,6 +1804,7 @@ class NetworkTrainer:
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
+        accelerator.register_for_checkpointing(loss_recorder)
         del train_dataset_group
 
         # function for saving/removing

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -77,6 +77,16 @@ class LossRecorder:
     def moving_average(self) -> float:
         return self.loss_total / len(self.loss_list)
 
+    def state_dict(self):
+        return {
+            "loss_list": self.loss_list,
+            "loss_total": self.loss_total,
+        }
+
+    def load_state_dict(self, state_dict):
+        self.loss_list = state_dict.get("loss_list", [])
+        self.loss_total = state_dict.get("loss_total", 0.0)
+
 
 def get_epoch_ckpt_name(model_name, epoch_no: int):
     return EPOCH_FILE_NAME.format(model_name, epoch_no) + ".safetensors"


### PR DESCRIPTION
## Summary
- implement `state_dict` and `load_state_dict` for `LossRecorder`
- register `LossRecorder` with `accelerator` so checkpointing saves it

## Testing
- `python -m py_compile utils/train_utils.py hv_train_network.py hv_train.py`

------
https://chatgpt.com/codex/tasks/task_e_6865195136b88321829a17a2233f50ec